### PR TITLE
Separate the extensions

### DIFF
--- a/docs/collaboration/index.md
+++ b/docs/collaboration/index.md
@@ -18,9 +18,9 @@ This document describes a possible way to combine the three OCFL Extensions to a
   |       ├── packaging_format_inventory.json
   |       ├── packaging_format_inventory.json.sha512
   │       └── packaging_formats
-  │           ├── 40cdd53d9a263e5466b8954d82d23daa
+  │           ├── 05b408a38e341de9bb4316aa812115ee 
   │               └── ... files describing the packaging_format ...
-  │           └── 95d751340dcdc784fd759dbc7ddb9633
+  │           └── 76f773808534f2969d7a405b99e78b11 
   │               └── ... files describing the packaging_format ...  
   ├── 0de
   |   └── 45c
@@ -43,8 +43,8 @@ This document describes a possible way to combine the three OCFL Extensions to a
 
 the config.json in the property-registry extension declares which storage-root extensions might be used in the object-version-properties.json in the object versions.
 
+
 ```
-property-registry/config.json
 {
   "archival-date" : {
       "description" : "The date on which this Object Version has been archived in this repository"
@@ -76,10 +76,10 @@ property-registry/config.json
     "type" : "object",
     "extension" : "packaging-format-registry",
     "mandatory" : true,
-    properties" : [{
+    "properties" : [{
       "description" : "the packaging format used for this object version",
       "type" : "string",
-      "constraint" : "one of the keys in the packaging-format-registry.json",
+      "constraint" : "a name/version pair defined in the packaging-format-registry.json",
       "mandatory": true
     }]
   }
@@ -91,16 +91,14 @@ and two examples of different possible instantiations of `object_version_propert
 
 
 ```
-object_version_properties.json
-
 {
   "v2": {
     "archival-date" : "2020-09-28T16:22:44",
-    "packaging-format": "BagIt v0.97"
+    "packaging-format": "BagIt/v0.97"
   },
   "v1": {
     "archival-date" : "2018-03-19T06:22:11",
-    "packaging-format": "DANS RDA BagPack v0.1.0",
+    "packaging-format": "BagIt/v0.97",
     "deaccessioned": {
       "datetime": "2020-09-28T13:55:00",
       "reason": "Deaccessioned because dataset was deleted in Easy"
@@ -108,14 +106,13 @@ object_version_properties.json
   }
 }
 ```
+another example of `object_version_properties.json`:
 
 ```
-object_version_properties.json
-
 {
   "v1": {
     "archival-date" : "2002-07-12T15:14:33",
-    "packaging-format": "DANS RDA BagPack v0.1.0"    
+    "packaging-format": "BagIt/v1.0"    
   }
 }
 ```

--- a/docs/collaboration/index.md
+++ b/docs/collaboration/index.md
@@ -1,0 +1,122 @@
+# Collaboration of these three OCFL Extensions
+
+This document describes a possible way to combine the three OCFL Extensions to achieve a way to prescribe the properties to be recorded and how to record them for each OCFL Object Version.
+
+```
+[storage_root]
+  ├── 0=ocfl_1.0
+  ├── ocfl_1.0.txt
+  ├── ocfl_layout.json
+  ├── object-version-properties.md
+  ├── packaging-format-registry.md
+  ├── property-registry.md
+  ├── extensions
+  |   ├── property-registry/
+  |   |   └── config.json  
+  │   └── packaging-format-registry/
+  │       ├── config.json
+  |       ├── packaging_format_inventory.json
+  |       ├── packaging_format_inventory.json.sha512
+  │       └── packaging_formats
+  │           ├── 40cdd53d9a263e5466b8954d82d23daa
+  │               └── ... files describing the packaging_format ...
+  │           └── 95d751340dcdc784fd759dbc7ddb9633
+  │               └── ... files describing the packaging_format ...  
+  ├── 0de
+  |   └── 45c
+  |       └── f24
+  |           └── item1
+  │               └── 0=ocfl_object_1.0
+  │                   ├── inventory.json
+  │                   ├── inventory.json.sha512
+  |                   └── extensions
+  │                       └── object-version-properties/
+  │                           ├── object_version_properties.json
+  │                           └── object_version_properties.json.sha512
+  └────────────────── v1/
+                      ├── inventory.json
+                      ├── inventory.json.sha512
+                      └── content/
+                          └── ... files ...
+  
+```
+
+the config.json in the property-registry extension declares which storage-root extensions might be used in the object-version-properties.json in the object versions.
+
+```
+property-registry/config.json
+{
+  "archival-date" : {
+      "description" : "The date on which this Object Version has been archived in this repository"
+      "type" : "string", 
+      "constraint": "a datetime in ISO 8601 YYYY-MM-DDTHH-mm-ss format",
+      "mandatory" : true
+  },
+  "deaccessioned" : {
+    "description" : "If given, this version of the object has been deaccessioned and should not be disseminated",
+    "type" : "object",
+    "constraint": "",
+    "mandatory" : false,
+    "properties" [{
+      "name" : "datetime",
+      "description" : "The date on which this object version has been deaccessioned",
+      "type" : "string", 
+      "constraint": "a datetime in ISO 8601 YYYY-MM-DDTHH-mm-ss format",
+      "mandatory" : true
+    }, {
+      "name" : "reason",
+      "description": "The reason why this object version has been deaccessioned.",
+      "type" : "string",
+      "constraint" : "",
+      "mandatory": true
+    }]
+  },
+  "packaging-format" : {
+    "description" : "The packaging format of this Object Version",
+    "type" : "object",
+    "extension" : "packaging-format-registry",
+    "mandatory" : true,
+    properties" : [{
+      "description" : "the packaging format used for this object version",
+      "type" : "string",
+      "constraint" : "one of the keys in the packaging-format-registry.json",
+      "mandatory": true
+    }]
+  }
+}
+```
+
+
+and two examples of different possible instantiations of `object_version_properties.json`
+
+
+```
+object_version_properties.json
+
+{
+  "v2": {
+    "archival-date" : "2020-09-28T16:22:44",
+    "packaging-format": "BagIt v0.97"
+  },
+  "v1": {
+    "archival-date" : "2018-03-19T06:22:11",
+    "packaging-format": "DANS RDA BagPack v0.1.0",
+    "deaccessioned": {
+      "datetime": "2020-09-28T13:55:00",
+      "reason": "Deaccessioned because dataset was deleted in Easy"
+    } 
+  }
+}
+```
+
+```
+object_version_properties.json
+
+{
+  "v1": {
+    "archival-date" : "2002-07-12T15:14:33",
+    "packaging-format": "DANS RDA BagPack v0.1.0"    
+  }
+}
+```
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ This site documents extensions for OCFL (the [Oxford Common File Layout](https:/
 
 Extensions
 ----------
-
+* [Collaboration](./collaboration/index.md) - gives examples how these OCFL Extentension can be used together.
 * [Object Version Properties](./object-version-properties/object-version-properties.md) - specifies how to document additional properties for a OCFL object version.
 * [Packaging Format Registry](./packaging-format-registry/packaging-format-registry.md) - specifies how to document how the content files of OCFL object versions are packaged.
+* [Property Registry](./property-registry/property-registry.md) - specifies properties and their definitions and structure.

--- a/docs/object-version-properties/object-version-properties.md
+++ b/docs/object-version-properties/object-version-properties.md
@@ -1,62 +1,39 @@
 # OCFL Extension: Object Version Properties
 
 - **Extension Name:** object-version-properties
-- **Authors:**
-- **Minimum OCFL Version:** 1.1 ?
+- **Authors:** 
+- **Minimum OCFL Version:** 1.0
 - **Status:** DRAFT
 
 ## Overview
-
-This extension facilitates a way to record metadata on an OCFL object version that is not recorded in the object version itself. This can be necessary because
-it is related to the repository (e.g. packaging format information) or because it is only available after the object version is already archived. Since OCFL
-repository objects are immutable, they cannot be changed. This includes deaccessioning or deletion actions. This extension only describes how the properties
-should be recorded, which properties to use are described in other extensions or in it's `config.json`.
+This extension facilitates a way to record metadata on an OCFL object version that is not recorded in the object version itself. This can be necessary because it is related to the repository (e.g. packaging format information) or because it is only available after the object version is already archived. Since OCFL repository objects are immutable, they cannot be changed.
+This includes deaccessioning or deletion actions.
+This extension only describes how the properties should be recorded, it does not prescribe which properties will be recorded.
 
 ## Parameters
-
-the `object_version_properties.json` file in every object_root contains entries for all versions in this object. Per version, it contains a list of keys (as
-declared in the `config.json` of this extension in the storage_root) and a value or object containing the properties defined in . Each property is declared in
-the `config.json` of the extension, and is described with the following attributes:
-`description`, `type`, `constraint`, `properties`, `extension` and `mandatory`.
-Some of these are disjunct.
-
-| key                    | description                                                                                        | required |
-|------------------------|----------------------------------------------------------------------------------------------------|----------|
-| description            | human readable explanation of this property                                                        | true     |
-| type                   | a json type (number, string, boolean or object). An object<br> needs the `properties` to be filled | true     |
-| extension              | if used, the name MUST be an extension in the storage_root<br> that describes the functionality    | false    |
-| constraint             |                                                                                                    | false    |
-| mandatory              | boolean                                                                                            | true     |
-| properties             | an array of properties with the following keys                                                     | false    |
-| properties.name        |                                                                                                    | true     |
-| properties.description |                                                                                                    | true     |
-| properties.type        | a json type (number, string, boolean)                                                              | true     |
-| properties.constraint  |                                                                                                    | false    |
-| properties.mandatory   | boolean whether this property is mandatory within the<br> parent object                            | true     |
+The `object_version_properties.json` file in the object_root extensions directory might contain entries for all versions in this object. Per version, it lists keys and a value or object containing subproperties.
 
 ## Implementation
+Implementing software might check the well-formedness of the `object-version-properties.json` in the extension folder of the object_root.
 
-Implementing software might check whether the extensions mentioned in the `config.json` are installed in the storage_root, and whether these have a valid
-`object-version-properties` object in their `config.json`.
+Implementing software might check whether the file `object-version-properties.json` is available for each OCFL Object and has a key for each version in this object.
+(**TODO:** maybe this should not be mandatory?)
 
-Implementing software might check for each additional object version into the object_root whether the `mandatory` properties are provided in the
-`object-version-properties.json` for this version.
+## Example
+Two examples will be given:
 
-## Examples
+1. a simple property
+2. a complex property
 
-### 1. Simple property
+### 1. a simple property
+if the repository wants to record a simple property, for instance the archival date for each OCFL Object Version, it could achieve that in the following way:
 
-If the repository wants to record a simple property, for instance the archival date for each OCFL Object Version, it could achieve that in the following way:
-
-```text
+```
 [storage_root]
   ├── 0=ocfl_1.0
   ├── ocfl_1.0.txt
   ├── ocfl_layout.json
   ├── object-version-properties.md
-  ├── extensions
-  |   └── object-version-properties
-  |       └── config.json    
   ├── 0de
   |   └── 45c
   |       └── f24
@@ -74,215 +51,27 @@ If the repository wants to record a simple property, for instance the archival d
                       └── content/
                           └── ... files ...
 ```
+the `object-version-properties.json` of the OCFL object could have the following entry:
 
-**[storage_root]/extensions/object-version-properties/config.json:**
-
-```json
+```
 {
-  "archival-date": {
-    "description": "The archival date of the current Object Version",
-    "type": "string",
-    "constraint": "a datetime in ISO 8601 YYYY-MM-DDTHH-mm-ss format",
-    "required": true
+  "v1" : {
+    "archival-date" : "2024-07-30T21:12:04"
   }
 }
 ```
 
-**[object_root]/extensions/object-version-properties.json:**
-
-```json
-{
-  "v1": {
-    "archival-date": "2025-10-15T13:19:00"
-  }
-}
-```
-
-### 2. Complex property
-
-If the repository wants to record a complex object for a version, for instance that it has been deaccessioned, this could be done with the same structure, but
-with a different content for `object-version-properties/config.json`. Note that the `type` is `object` and that it has a `properties` array with the property
-definitions.
-
-**[storage_root]/extensions/object-version-properties/config.json:**
-
-```json
-{
-  "deaccessioned": {
-    "description": "Object version has been deaccessioned and should not be disseminated",
-    "type": "object",
-    "constraint": "",
-    "required": false,
-    "properties": [
-      {
-        "name": "datetime",
-        "description": "Date and time of deaccessioning",
-        "type": "string",
-        "constraint": "a datetime in ISO 8601 YYYY-MM-DDTHH-mm-ss format",
-        "required": true
-      },
-      {
-        "name": "reason",
-        "description": "Reason of deaccessioning",
-        "type": "string",
-        "constraint": "",
-        "required": true
-      }
-    ]
-  }
-}
-```
-
-The `object-version-properties.json` of the OCFL object might have the following content. Note that the `deaccessioned` property is an object with two
-properties, `datetime` and `reason`.
-
-**[object_root]/extensions/object-version-properties.json:**
-
-```json
-{
-  "v1": {
-    "deaccessioned": {
-      "datetime": "2025-10-15T13:19:00",
-      "reason": "Deaccessioned because dataset was deleted in Easy"
-    }
-  }
-}
-```
-
-### 3. Complex property that uses another extension
-
-If the property to be recorded is described in an extension, it can reference that extension in `object-version-properties.json`.
-
-**[storage_root]/extensions/object-version-properties/config.json:**
-
-```json
-{
-  "packaging-format": {
-    "description": "The packaging format of this Object Version",
-    "type": "object",
-    "extension": "packaging-format-registry",
-    "required": true
-  }
-}
-```
-
-The `config.json` of the other extension should then describe the properties to be used. In this case, the `packaging-format-registry` extension is used to
-record the packaging format of the object version.
-
-**[storage_root]/extensions/packaging-format-registry/config.json:**
-
-```json
-{
-  "extensionName": "packaging-format-registry",
-  "version": "0.1.0",
-  "object-version-properties": {
-    "description": "the packaging format used for this object version",
-    "type": "string",
-    "constraint": "one of the keys in the packaging-format-registry.json",
-    "mandatory": true
-  }
-}
-```
-
-### 4. A complete example
-
-```text
-[storage_root]
-  ├── 0=ocfl_1.0
-  ├── ocfl_1.0.txt
-  ├── ocfl_layout.json
-  ├── object-version-properties.md
-  ├── packaging-format-registry.md
-  ├── extensions
-  |   ├── object-version-properties/
-  |   |   └── config.json  
-  │   └── packaging-format-registry/
-  │       ├── config.json
-  |       ├── packaging_format_inventory.json
-  |       ├── packaging_format_inventory.json.sha512
-  │       └── packaging_formats
-  │           ├── 40cdd53d9a263e5466b8954d82d23daa
-  │               └── ... files describing the packaging_format ...
-  │           └── 95d751340dcdc784fd759dbc7ddb9633
-  │               └── ... files describing the packaging_format ...  
-```
-
-The config.json in the `object-version-properties` extension declares which storage-root extensions can be used in the version-properties.json in the object
-versions.
-
-**[storage_root]/extensions/object-version-properties/config.json:**
-
-```json
-{
-  "archival-date": {
-    "description": "The date on which this Object Version has been archived in this repository",
-    "type": "string",
-    "constraint": "a datetime in ISO 8601 YYYY-MM-DDTHH-mm-ss format",
-    "mandatory": true
-  },
-  "deaccessioned": {
-    "description": "If given, this version of the object has been deaccessioned and should not be disseminated",
-    "type": "object",
-    "constraint": "",
-    "mandatory": false,
-    "properties": [
-      {
-        "name": "datetime",
-        "description": "The date on which this object version has been deaccessioned",
-        "type": "string",
-        "constraint": "a datetime in ISO 8601 YYYY-MM-DDTHH-mm-ss format",
-        "mandatory": true
-      },
-      {
-        "name": "reason",
-        "description": "The reason why this object version has been deaccessioned.",
-        "type": "string",
-        "constraint": "",
-        "mandatory": true
-      }
-    ]
-  },
-  "packaging-format": {
-    "description": "The packaging format of this Object Version",
-    "type": "object",
-    "extension": "packaging-format-registry",
-    "mandatory": true
-  }
-}
-``` 
-
-**[storage_root]/extensions/packaging-format-registry/config.json:**
-
-```json
-{
-  "extensionName" : "packaging-format-registry",
-  "version" : "0.1.0",
-  "object-version-properties" : {
-    "description" : "the packaging format used for this object version",
-    "type" : "string",
-    "constraint" : "one of the keys in the packaging-format-registry.json",
-    "mandatory": true
-  }
-}
+### 2. a complex property
+if the repository wants to record a complex object for a version, for instance that it has been deaccessioned, this could be done with a similar structure. The `object-version-properties.json` of the OCFL object might have the following entry:
 
 ```
-
-This can now be used in the `object_version_properties.json` file in the object root.
-
-**[object_root]/extensions/object-version-properties.json:**
-
-```json
 {
-  "v2": {
-    "archival-date": "2020-09-28T16:22:44",
-    "packaging-format": "BagIt v0.97"
-  },
-  "v1": {
-    "archival-date": "2018-03-19T06:22:11",
-    "packaging-format": "DANS RDA BagPack v0.1.0",
-    "deaccessioned": {
-      "datetime": "2020-09-28T13:55:00",
-      "reason": "Deaccessioned because dataset was deleted in Easy"
+  "v2": {"archival-date" : "2025-10-15T13:19:00"},
+  "v1" : {
+    "archival-date" : "2024-07-30T21:12:04"
+    "deaccessioned" : {
+      "datetime" : "2025-10-15T13:19:00",
+      "reason" : "Deaccessioned because dataset was deleted in Easy"
     }
   }
 }

--- a/docs/packaging-format-registry/packaging-format-registry.md
+++ b/docs/packaging-format-registry/packaging-format-registry.md
@@ -1,192 +1,92 @@
 # OCFL Extension: Packaging Format Registry
 
 - **Extension Name:** packaging-format-registry
-- **Authors:**
-- **Minimum OCFL Version:** 1.1
+- **Authors:** 
+- **Minimum OCFL Version:** 1.0
 - **Status:** DRAFT
 
-# Overview
+## Overview
+In order for an OCFL Repository to be self contained, it might want to explicitly define and declare the format with which an Object is packaged. This might not be the same for each version in an Object. 
+The definitions of the Packaging Format are placed in the storage_root extension directory. 
+The declarations can then be placed in the object_root extension directory for each object. How this is done is not defined in this extension. One way to do this is to use the Object-Version-Properties Extension.
 
-In order for an OCFL Repository to be self-contained, it may want to explicitly define and declare the packaging format used for each OCFL Object Version. We
-broadly define "packaging format" as a set of rules about the way the content files of an OCFL Object Version are laid out, organized, and described. We
-describe the packaging format registry as a directory containing subdirectories, each of which describes a specific packaging format.
+## Parameters
+### packaging_format_inventory.json
 
-# Parameters
+A manifest of the registered Packaging Formats must be maintained in `packaging_format_inventory.json`. 
 
-## packaging_format_inventory.json
-
-A manifest of the registered Packaging Formats must be maintained in`packaging_format_inventory.json`.
-
-- Name:`manifest`
+- Name: `manifest`
     - Description: Object containing manifest entries.
     - Type: Object
-    - Constraints: Must contain one entry per registered Packaging Format; may contain 3 sub-keys documented below. These entry names must be short enough to be
-      easily used in the version_packaging_format.json
+    - Constraints: Must contain one entry per registered Packaging Format; may contain 3 sub-keys documented below. These entry names must be short enough to be easily used in the version_packaging_format.json
     - Default: Not applicable
 
-### manifest entry properties for `packaging_format_inventory.json`
+### manifest entry properties for `packaging_format_inventory.json`
 
-- Name:`name`
-    - Description: The human-readable name of the packaging format.
+- Name: `name`
+    - Description: The human readable name of the packaging format.
     - Type: String
     - Constraints: Not applicable
     - Default: Not applicable
-- Name:`version`
-    - Description: Version of this packaging format.
+- Name: `version`
+    - Description: Version of this packaging format. 
     - Type: String
     - Constraints: The `name` and `version` together must be unique for the packaging formats in this storage root ``
     - Default: Not applicable
-- Name:`summary`
+- Name: `summary`
     - Description: Short description of the packaging format
     - Type: String
     - Constraints: Not applicable
     - Default: Not applicable
 
-# Implementation
+## Implementation
+An OCFL Repository with this extension enabled can add extra information for each OCFL Object Version that is added to the Repository. For every new OCFL Object/Version the Packaging Format for that Object/Version could be recorded.
 
-An OCFL Repository with this extension enabled must add extra information for each OCFL Object Version that is added to the Repository. For every new OCFL
-Object/Version the Packaging Format for that Object/Version must be recorded.
-
-To add a new packaging format to the OCFL Root the packaging_format_inventory.json must be updated and the files describing the Packaging Format must be placed
-in the `packaging_formats` folder under that subfolder.
+To add a new packaging format to the OCFL Root the packaging_format_inventory.json must be updated and the files describing the Packaging Format must be placed in the `packaging_formats` folder under that subfolder. 
 
 How this Packaging Format is recorded, is not specified in this extension. One possible way would be to use the OCFL extension `Object Version Properties`.
 
 When reading an OCFL Object Version the recorded Packaging Format can be consulted for more info on the packaging format of this version.
 
-# Example
-
-The packaging_format_inventory.json contains the manifest with the available OCFL Object Packaging Formats for this OCFL Repository.
-
-**[storage_root]/extensions/packaging-format-registry/packaging_format_inventory.json**
-
-```json
-{
-    "manifest" : {
-        "40cdd53d9a263e5466b8954d82d23daa" : {
-            "name" : "BagIt",
-            "version" : "v0.97",
-            "summary" : ""
-        }, 
-        "95d751340dcdc784fd759dbc7ddb9633" : {
-            "name" : "BagIt",
-            "version" : "v1.0",
-            "summary" : "https://datatracker.ietf.org/doc/html/rfc8493"
-        }
-    }
-}
-```
-
-In this example we use the Object Version Properties Extension to record the Packaging Format used for each version in this OCFL Object
-
-**[object_root]/extensions/object-version-properties/object_version_properties.json**
-
-```json
-{
-    "v1" : {
-      "packaging-format": "40cdd53d9a263e5466b8954d82d23daa"
-    }
-}
-```
-
-The complete OCFL Repository would then look something like this:
-
-```text
-[storage_root]
-  ├── 0=ocfl_1.0
-  ├── ocfl_1.0.txt
-  ├── ocfl_layout.json
-  ├── extensions
-  |   ├── object-version-properties/
-  |   |   └── config.json
-  │   └── packaging-format-registry/
-  │       ├── config.json
-  |       ├── packaging_format_inventory.json
-  |       ├── packaging_format_inventory.json.sha512
-  │       └── packaging_formats
-  │           ├── 40cdd53d9a263e5466b8954d82d23daa
-  │               └── ... files describing the packaging_format ...
-  │           └── 95d751340dcdc784fd759dbc7ddb9633
-  |               ├── rfc8493.txt
-  │               └── ... files describing the packaging_format ...  
-  ├── 0de
-  |   └── 45c
-  |       └── f24
-  |           └── item1
-  │               └── 0=ocfl_object_1.0
-  │                   ├── inventory.json
-  │                   ├── inventory.json.sha512
-  |                   └── extensions
-  │                       └── object-version-properties/
-  │                           ├── object_version_properties.json
-  │                           └── object_version_properties.json.sha512
-  └────────────────── v1/
-                      ├── inventory.json
-                      ├── inventory.json.sha512
-                      └── content/
-                          └── ... files ...
-  
-```
-
-# our use case
+## Example
+The packaging_format_inventory.json contains the manifest with the available OCFL Object Packaging Formats for this OCFL Repository. 
 
 ```
 packaging_format_inventory.json
 {
-    "manifest" : {
-        "6619641f-6504-447f-9c63-1cfc71815f97" : {
-            "name" : "DANS RDA BagPack"
-            "version" : "v1"
-            "summary" : "A BagIt-based Packaging Format defined by the RDA, with additional rules specified by DANS"
-        }
+  "manifest" : {
+    "40cdd53d9a263e5466b8954d82d23daa" : {
+      "name" : "BagIt"
+      "version" : "v0.97"
+      "summary" : "a hierarchical file packaging format for storage and transfer of arbitrary digital content."
+    }, 
+    "95d751340dcdc784fd759dbc7ddb9633" : {
+      "name" : "BagIt"
+      "version" : "v1.0"
+      "summary" : "https://datatracker.ietf.org/doc/html/rfc8493"
     }
+  }
 }
 ```
 
-```
-version_packaging_format.json
-{
-    "v1" : "6619641f-6504-447f-9c63-1cfc71815f97"
-}
-```
 
-Placing this packaging-format.md file in the storage_root of an OCFL repository allows for this extension to be used in the extensions directory of the
-storage_root and object_root.
+The complete OCFL Repository would then look something like this: 
 
 ```
 [storage_root]
   ├── 0=ocfl_1.0
   ├── ocfl_1.0.txt
   ├── ocfl_layout.json
-  ├── object-version-registry.md
-  ├── packaging-format-registry.md 
-  ├── extensions/
-  |   ├── object-version-properties/
-  |   |   └── config.json
-  │   └── packaging-format-registry/
-  │       ├── config.json
-  |       ├── packaging_format_inventory.json
-  |       ├── packaging_format_inventory.json.sha512
-  │       └── packaging_formats
-  │           └── 6619641f-6504-447f-9c63-1cfc71815f97
-  |               ├── RDA bagpack DANS profile v1.json 
-  |               ├── RDA bagpack DANS profile v1.md  
-  │               └── Research Data Repository Interoperability WG Final Recommendations.pdf
-  ├── 0de
-  |   └── 45c
-  |       └── f24
-  |           └── item1
-  │               └── 0=ocfl_object_1.0
-  │                   ├── inventory.json
-  │                   ├── inventory.json.sha512
-  |                   └── extensions/
-  │                       └── object-version-properties/
-  │                           ├── object_version_properties.json
-  │                           └── object_version_properties.json.sha512
-  └────────────────── v1/
-                      ├── inventory.json
-                      ├── inventory.json.sha512
-                      └── content/
-                          └── ... files ...
+  └── extensions
+      └── packaging-format-registry/
+          ├── config.json
+          ├── packaging_format_inventory.json
+          ├── packaging_format_inventory.json.sha512
+          └── packaging_formats
+              ├── 40cdd53d9a263e5466b8954d82d23daa
+              |   └── ... files describing the packaging_format ...
+              └── 95d751340dcdc784fd759dbc7ddb9633
+                  ├── rfc8493.txt
+                  └── ... files describing the packaging_format ...  
   
 ```

--- a/docs/packaging-format-registry/packaging-format-registry.md
+++ b/docs/packaging-format-registry/packaging-format-registry.md
@@ -11,6 +11,27 @@ The definitions of the Packaging Format are placed in the storage_root extension
 The declarations can then be placed in the object_root extension directory for each object. How this is done is not defined in this extension. One way to do this is to use the Object-Version-Properties Extension.
 
 ## Parameters
+### config.json
+Configuration is done by setting values in config.json at the top level of the extension's directory. The keys expected are:
+
+- Name: extensionName
+ - Description: String identifying the extension.
+ - Type: String
+ - Constraints: Must be packaging-format-registry.
+ - Default: packaging-format-registry
+
+- Name: packagingFormatDigestAlgorithm
+ - Description: Algorithm used for calculating safe filenames from packaging formats. Use `name`/`version` as input.
+ - Type: String
+ - Constraints: Must be a valid digest algorithm returning strings which are safe file names on the target file system.
+ - Default: md5
+
+- Name: digestAlgorithm
+ - Description: Digest algorithm used for calculating fixity of the packaging registry inventory.
+ - Type: String
+ - Constraints: Must be a valid digest algorithm.
+ - Default: The same value used elsewhere in the OCFL for integrity checking.
+
 ### packaging_format_inventory.json
 
 A manifest of the registered Packaging Formats must be maintained in `packaging_format_inventory.json`. 
@@ -18,10 +39,10 @@ A manifest of the registered Packaging Formats must be maintained in `packaging
 - Name: `manifest`
     - Description: Object containing manifest entries.
     - Type: Object
-    - Constraints: Must contain one entry per registered Packaging Format; may contain 3 sub-keys documented below. These entry names must be short enough to be easily used in the version_packaging_format.json
+    - Constraints: Must contain one entry per registered Packaging Format; may contain 3 sub-keys documented below. These entry names must be short enough to be easily used to identify the packaging format.
     - Default: Not applicable
 
-### manifest entry properties for `packaging_format_inventory.json`
+#### manifest entry properties for `packaging_format_inventory.json`
 
 - Name: `name`
     - Description: The human readable name of the packaging format.
@@ -40,13 +61,29 @@ A manifest of the registered Packaging Formats must be maintained in `packaging
     - Default: Not applicable
 
 ## Implementation
-An OCFL Repository with this extension enabled can add extra information for each OCFL Object Version that is added to the Repository. For every new OCFL Object/Version the Packaging Format for that Object/Version could be recorded.
+An OCFL Repository with this extension enabled can add extra information for each OCFL object/version that is added to the Repository. For every new OCFL object/version the Packaging Format for that object/version could be recorded.
 
 To add a new packaging format to the OCFL Root the packaging_format_inventory.json must be updated and the files describing the Packaging Format must be placed in the `packaging_formats` folder under that subfolder. 
+
+A process could be implemented which ensures all OCFL objects/versions written are checked for packaging format references. Where not already registered, the packaging format must be documented and registered as described below. The packaging format is identified by the name and version referenced. The digest of the `name`/`version` (as configured by identifierDigestAlgorithm) must be used as a filename. MD5 may be sufficient, other algorithms may be configured.
+
+The values of digestAlgorithm and identifierDigestAlgorithm should not be changed once the registry is initialised. If changing the digest is unavoidable, all existing entries in the registry must be updated to the new algorithm(s).
 
 How this Packaging Format is recorded, is not specified in this extension. One possible way would be to use the OCFL extension `Object Version Properties`.
 
 When reading an OCFL Object Version the recorded Packaging Format can be consulted for more info on the packaging format of this version.
+
+### Registering a packaging format with the extension
+For each referenced packaging format in the OCFL object/versions:
+
+* the entry in the storage_root extension is derived by hashing the `name`/`version` of the packaging format using the configured `packagingFormatDigestAlgorithm`. 
+* the manifest object in the `packaging-format-registry.json` must be checked for this key.
+* if this key is not already present in the registry:
+ * Documentation of the packaging format must be collected, and stored in the packaging format directory with the derived local filename.
+ * The packaging_format_inventory.json must updated:
+  * a new key must be created in the manifest object, with the defined properties.
+ * The packaging_format_inventory.json’s sidecar file must also be updated with the appropriate checksum.
+
 
 ## Example
 The packaging_format_inventory.json contains the manifest with the available OCFL Object Packaging Formats for this OCFL Repository. 
@@ -55,12 +92,12 @@ The packaging_format_inventory.json contains the manifest with the available OCF
 packaging_format_inventory.json
 {
   "manifest" : {
-    "40cdd53d9a263e5466b8954d82d23daa" : {
+    "76f773808534f2969d7a405b99e78b11" : {
       "name" : "BagIt"
       "version" : "v0.97"
       "summary" : "a hierarchical file packaging format for storage and transfer of arbitrary digital content."
     }, 
-    "95d751340dcdc784fd759dbc7ddb9633" : {
+    "05b408a38e341de9bb4316aa812115ee" : {
       "name" : "BagIt"
       "version" : "v1.0"
       "summary" : "https://datatracker.ietf.org/doc/html/rfc8493"
@@ -70,7 +107,7 @@ packaging_format_inventory.json
 ```
 
 
-The complete OCFL Repository would then look something like this: 
+The storage root of the OCFL Repository would then look something like this: 
 
 ```
 [storage_root]
@@ -83,10 +120,10 @@ The complete OCFL Repository would then look something like this:
           ├── packaging_format_inventory.json
           ├── packaging_format_inventory.json.sha512
           └── packaging_formats
-              ├── 40cdd53d9a263e5466b8954d82d23daa
-              |   └── ... files describing the packaging_format ...
-              └── 95d751340dcdc784fd759dbc7ddb9633
-                  ├── rfc8493.txt
-                  └── ... files describing the packaging_format ...  
+              ├── 05b408a38e341de9bb4316aa812115ee
+              |   ├── rfc8493.txt
+              |   └── ... files describing the packaging_format BagIt/v1.0 ...
+              └── 76f773808534f2969d7a405b99e78b11                  
+                  └── ... files describing the packaging_format BagIt/v0.97 ...  
   
 ```

--- a/docs/property-registry/property-registry.md
+++ b/docs/property-registry/property-registry.md
@@ -10,7 +10,7 @@ This extension facilitates a way to define properties for an OCFL object.
 This extension only describes which properties could be recorded, and their definitions and structures. It does not prescribe how these are stored for objects or object versions. 
 
 ## Parameters
-The `config.json` in this extension defines the properties using the following keys: `name`, 
+The `config.json` in this extension has the key `extensionName`. Furthermore it defines the properties using the following keys: `name`, 
 `description`, `type`, `constraint`, `properties`, `extension` and `mandatory`. 
 
 
@@ -58,6 +58,7 @@ with the following content for `property-registry/config.json`:
 
 ```
 {
+  "extensionName" : "property-registry",
   "archival-date" : {
       "description" : "The date on which this Object Version has been archived in this repository"
       "type" : "string", 
@@ -73,6 +74,7 @@ if the repository wants to record a complex object for a version, for instance t
 
 ```
 {
+  "extensionName" : "property-registry",
   "deaccessioned" : {
     "description" : "If given, this version of the object has been deaccessioned and should not be disseminated",
     "type" : "object",
@@ -100,6 +102,7 @@ If the property to be recorded is described in an extension, the `property-regis
 
 ```
 {
+  "extensionName" : "property-registry",
   "packaging-format" : {
     "description" : "The packaging format of this Object Version",
     "type" : "object",
@@ -108,7 +111,7 @@ If the property to be recorded is described in an extension, the `property-regis
     "properties" : [{
       "description" : "the packaging format used for this object version",
       "type" : "string",
-      "constraint" : "one of the keys in the packaging-format-registry.json",
+      "constraint" : "one of the name/version pairs in the packaging-format-registry.json",
       "mandatory": true
     }]
   }
@@ -132,9 +135,9 @@ If the property to be recorded is described in an extension, the `property-regis
   |       ├── packaging_format_inventory.json
   |       ├── packaging_format_inventory.json.sha512
   │       └── packaging_formats
-  │           ├── 40cdd53d9a263e5466b8954d82d23daa
-  │               └── ... files describing the packaging_format ...
-  │           └── 95d751340dcdc784fd759dbc7ddb9633
+  │           ├── 05b408a38e341de9bb4316aa812115ee
+  │           |   └── ... files describing the packaging_format ...
+  │           └── 76f773808534f2969d7a405b99e78b11
   │               └── ... files describing the packaging_format ...  
 ```
 
@@ -142,6 +145,7 @@ If the property to be recorded is described in an extension, the `property-regis
 
 ```
 {
+  "extensionName" : "property-registry",
   "archival-date" : {
       "description" : "The date on which this Object Version has been archived in this repository"
       "type" : "string", 
@@ -177,7 +181,7 @@ If the property to be recorded is described in an extension, the `property-regis
     "properties" : [{
       "description" : "the packaging format used for this object version",
       "type" : "string",
-      "constraint" : "one of the keys in the packaging-format-registry.json",
+      "constraint" : "one of the name/version pairs defined in the packaging-format-registry.json",
       "mandatory": true
     }]
   }

--- a/docs/property-registry/property-registry.md
+++ b/docs/property-registry/property-registry.md
@@ -1,0 +1,185 @@
+# OCFL Extension: Property Registry
+
+- **Extension Name:** property-registry
+- **Authors:** 
+- **Minimum OCFL Version:** 1.0
+- **Status:** DRAFT
+
+## Overview
+This extension facilitates a way to define properties for an OCFL object.
+This extension only describes which properties could be recorded, and their definitions and structures. It does not prescribe how these are stored for objects or object versions. 
+
+## Parameters
+The `config.json` in this extension defines the properties using the following keys: `name`, 
+`description`, `type`, `constraint`, `properties`, `extension` and `mandatory`. 
+
+
+|key|description|mandatory|
+|---|---|---|
+|description|human readable explanation of this property|true|
+|type| a json type (number, string, boolean or object). An object needs the `properties` to be filled|true|
+|extension| if used, the name MUST be an extension in the storage_root that describes the functionality|false|
+|constraint||false|
+|mandatory| boolean|true|
+|properties| an array of properties with the following keys|false|
+|property.name||true|
+|property.description||true|
+|property.type| a json type (number, string, boolean)|true|
+|property.constraint||false|
+|property.mandatory|boolean whether this property is mandatory within the parent object|true|
+
+## Implementation
+Implementing software might check whether the extensions mentioned in the `config.json` are installed in the storage_root.
+
+Implementing software might check whether the `config.json` is well-formed.
+
+
+## Example
+Three examples will be given:
+
+1. a simple property
+2. a complex property
+3. a complex property that uses another extension
+
+### 1. a simple property
+if the repository wants to record a simple property, for instance the archival date for each OCFL Object Version, it could achieve that in the following way:
+
+```
+[storage_root]
+  ├── 0=ocfl_1.0
+  ├── ocfl_1.0.txt
+  ├── ocfl_layout.json
+  ├── property-registry.md
+  ├── extensions
+      └── property-registry/
+          └── config.json    
+```
+with the following content for `property-registry/config.json`:
+
+```
+{
+  "archival-date" : {
+      "description" : "The date on which this Object Version has been archived in this repository"
+      "type" : "string", 
+      "constraint": "a datetime in ISO 8601 YYYY-MM-DDTHH-mm-ss format",
+      "mandatory" : true
+    },
+}
+```
+
+
+### 2. a complex property
+if the repository wants to record a complex object for a version, for instance that it has been deaccessioned, this could be done with the same structure, but with a different content for `property-registry/config.json`:
+
+```
+{
+  "deaccessioned" : {
+    "description" : "If given, this version of the object has been deaccessioned and should not be disseminated",
+    "type" : "object",
+    "constraint" ""
+    "mandatory" : false,
+    "properties" [{
+      "name" : "datetime"
+      "description" : "The date on which this object version has been deaccessioned"
+      "type" : "string", 
+      "constraint": "a datetime in ISO 8601 YYYY-MM-DDTHH-mm-ss format",
+      "mandatory" : true
+    }, {
+      "name" : "reason",
+      "description": "The reason why this object version has been deaccessioned.",
+      "type" : "string",
+      "constraint" : "",
+      "mandatory": true
+    }]
+  }
+}
+```
+
+### 3. a complex property that uses another extension
+If the property to be recorded is described in an extension, the `property-registry/config.json` would look like this:
+
+```
+{
+  "packaging-format" : {
+    "description" : "The packaging format of this Object Version",
+    "type" : "object",
+    "extension" : "packaging-format-registry",
+    "mandatory" : true
+    "properties" : [{
+      "description" : "the packaging format used for this object version",
+      "type" : "string",
+      "constraint" : "one of the keys in the packaging-format-registry.json",
+      "mandatory": true
+    }]
+  }
+}
+```
+
+### A storage_root with all the above examples implemented
+
+```
+[storage_root]
+  ├── 0=ocfl_1.0
+  ├── ocfl_1.0.txt
+  ├── ocfl_layout.json
+  ├── property-registry.md
+  ├── packaging-format-registry.md
+  ├── extensions
+  |   ├── property-registry/
+  |   |   └── config.json  
+  │   └── packaging-format-registry/
+  │       ├── config.json
+  |       ├── packaging_format_inventory.json
+  |       ├── packaging_format_inventory.json.sha512
+  │       └── packaging_formats
+  │           ├── 40cdd53d9a263e5466b8954d82d23daa
+  │               └── ... files describing the packaging_format ...
+  │           └── 95d751340dcdc784fd759dbc7ddb9633
+  │               └── ... files describing the packaging_format ...  
+```
+
+`property-registry/config.json` would then contain the following json:
+
+```
+{
+  "archival-date" : {
+      "description" : "The date on which this Object Version has been archived in this repository"
+      "type" : "string", 
+      "constraint": "a datetime in ISO 8601 YYYY-MM-DDTHH-mm-ss format",
+      "mandatory" : true
+  },
+  "deaccessioned" : {
+    "description" : "If given, this version of the object has been deaccessioned and should not be disseminated",
+    "type" : "object",
+    "constraint": "",
+    "mandatory" : false,
+    "properties" [
+      {
+        "name" : "datetime",
+        "description" : "The date on which this object version has been deaccessioned",
+        "type" : "string", 
+        "constraint": "a datetime in ISO 8601 YYYY-MM-DDTHH-mm-ss format",
+        "mandatory" : true
+      }, {
+        "name" : "reason",
+        "description": "The reason why this object version has been deaccessioned.",
+        "type" : "string",
+        "constraint" : "",
+        "mandatory": true
+      }
+    ]
+  },
+  "packaging-format" : {
+    "description" : "The packaging format of this Object Version",
+    "type" : "object",
+    "extension" : "packaging-format-registry",
+    "mandatory" : true,
+    "properties" : [{
+      "description" : "the packaging format used for this object version",
+      "type" : "string",
+      "constraint" : "one of the keys in the packaging-format-registry.json",
+      "mandatory": true
+    }]
+  }
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,9 @@ repo_url: https://github.com/DANS-KNAW/dans-ocfl-extensions
 nav:
   - Welcome: index.md
   - Object Version Properties: object-version-properties/object-version-properties.md
-  - Packaging Format: packaging-format-registry/packaging-format-registry.md
+  - Packaging Format Registry: packaging-format-registry/packaging-format-registry.md
+  - Property Registry: property-registry/property-registry.md
+  - Collaboration: collaboration/index.md
   - ⇒ DANS Data Station Architecture: arch.md
 
 plugins:


### PR DESCRIPTION
Separate the extensions for the registration of the properties and for the use of properties

Accompanies DD-1889

# Description of changes
We now specify three separate extensions:
* object-version-properties: to record properties per object version in the object_root
* packaging-format-registry: a registry that defines packaging formats for objects
* property-registry: a registry that defines properties, their intended use and subproperties

and a collaboration document detailing how these three extensions work in together to record properties for OCFL Object Versions.



# Notify
@DANS-KNAW/core-systems
